### PR TITLE
chore: add postgres docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: aesir_dev
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  pgdata:
+


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yml` configuration to the project, making it easier to set up and run a local PostgreSQL database for development. The most important change is the addition of a Docker service for PostgreSQL, including environment variables, volume mapping, and port configuration.

Local development environment setup:

* Added a new `docker-compose.yml` file that defines a `da` service using the official `postgres` image, with automatic restart, database name and password environment variables, persistent volume storage, and port mapping for local access.