### PR TITLE
fix: seeds

### DIFF
--- a/apps/commons/mix.exs
+++ b/apps/commons/mix.exs
@@ -54,7 +54,7 @@ defmodule Commons.MixProject do
 
   defp aliases() do
     [
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run apps/commons/priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]

--- a/apps/commons/priv/repo/seeds.exs
+++ b/apps/commons/priv/repo/seeds.exs
@@ -10,7 +10,7 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Aesir.Commons/Auth
+alias Aesir.Commons.Auth
 
 # Create test accounts for development
 test_accounts = [
@@ -55,7 +55,7 @@ Enum.each(test_accounts, fn attrs ->
         {:error, changeset} ->
           IO.puts("✗ Failed to create account #{attrs.userid}: #{inspect(changeset.errors)}")
       end
-    
+
     _account ->
       IO.puts("- Account #{attrs.userid} already exists")
   end


### PR DESCRIPTION
This pull request makes minor updates to the `commons` application to fix the path for the seeds file and correct a module alias. These changes ensure the database setup and seeding process work as intended.

* Fixed the path for the seeds file in the `ecto.setup` alias in `mix.exs` to point to `apps/commons/priv/repo/seeds.exs`, ensuring the correct file is used during setup.
* Corrected the module alias in `priv/repo/seeds.exs` from `Aesir.Commons/Auth` to `Aesir.Commons.Auth` for proper module referencing.